### PR TITLE
Add Runpod VC2 “Quick Generate” to Vite app + CORS on API (generate videos and display them)

### DIFF
--- a/source/api.ts
+++ b/source/api.ts
@@ -1,0 +1,50 @@
+export type GenerateReq = { prompt: string; seconds?: number; steps?: number };
+export type GenerateResp = { job_id: string };
+export type Job =
+  | { status: "queued" | "running" }
+  | { status: "done"; url: string }
+  | { status: "error"; error: string };
+
+const BASE = (import.meta.env.VITE_RUNPOD_BASE as string || "")
+  .trim()
+  .replace(/\/$/, "");
+
+if (!BASE) {
+  // Optional: helpful log so you notice if the env isn't set
+  console.warn("VITE_RUNPOD_BASE is missing. Set it in .env.local");
+}
+
+
+export async function startJob(body: GenerateReq): Promise<string> {
+  console.log(BASE);
+  console.log(JSON.stringify(body),);
+  const r = await fetch(`${BASE}/generate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!r.ok) throw new Error(`startJob failed: ${r.status}`);
+  const json = (await r.json()) as GenerateResp;
+  if (!json.job_id) throw new Error("No job_id in response");
+  return json.job_id;
+}
+
+export async function getJob(id: string): Promise<Job> {
+  const r = await fetch(`${BASE}/jobs/${encodeURIComponent(id)}`, { cache: "no-store" });
+  if (!r.ok) throw new Error(`getJob failed: ${r.status}`);
+  return (await r.json()) as Job;
+}
+
+export async function pollUntilDone(id: string, ms = 3000, signal?: AbortSignal): Promise<string> {
+  const BASE = (import.meta.env.VITE_RUNPOD_BASE as string).replace(/\/$/, "");
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (signal?.aborted) throw new Error("Cancelled");
+    const r = await fetch(`${BASE}/jobs/${encodeURIComponent(id)}`, { cache: "no-store" });
+    if (!r.ok) throw new Error(`getJob failed: ${r.status}`);
+    const j = await r.json() as any;
+    if (j.status === "done") return new URL(j.url, BASE).toString(); // <— absolute!
+    if (j.status === "error") throw new Error(j.error || "Job failed");
+    await new Promise(res => setTimeout(res, ms));
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,8 @@ export default defineConfig(({ mode }) => {
     return {
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+        'process.env.VITE_RUNPOD_BASE': JSON.stringify(env.RUNPOD_BASE),
       },
       resolve: {
         alias: {


### PR DESCRIPTION
# Summary

Adds a minimal, non-invasive “Prompt → Generate → Show video” flow that calls our VideoCrafter2 FastAPI on Runpod. Keeps all existing app behavior intact.
<img width="675" height="734" alt="image" src="https://github.com/user-attachments/assets/ede57fa2-90ed-4693-8161-fc871e9cb0ef" />


# What’s in this PR
	•	Frontend
	•	.env.local support for VITE_RUNPOD_BASE (Runpod API base URL).
	•	src/api.ts: tiny client (startJob, pollUntilDone) that:
	•	POST /generate to start a job
	•	polls GET /jobs/:id until done
	•	returns an absolute MP4 URL.
	•	App.tsx: new “Quick Generate (VC2)” section:
	•	prompt textarea + seconds/steps inputs
	•	Generate button
	•	status text + inline <video> preview and download link
	•	No changes to existing edit/remix flow or components.
	•	Backend (FastAPI)
	•	CORS enabled (allow all) to permit browser calls during dev/demo.

# Env

Add to frontend: `VITE_RUNPOD_BASE=https://<your-runpod-8000-url>`